### PR TITLE
Enable/Disable collector registration in configuration file

### DIFF
--- a/is_iot_sink/allowed_collectors.py
+++ b/is_iot_sink/allowed_collectors.py
@@ -8,14 +8,24 @@ class AllowedCollectors:
     def __init__(self):
         self.__collectors = {}
         self.__expire_time = int(utils.get_setting("collectors/expireTime"))
+        self.__registration_enabled = True if utils.get_setting("collectors/registrationEnabled").lower() == "true" else False
         self.__check_thread = threading.Thread(target=self.__check_all, daemon=True)
         self.__check_thread.start()
+
+    def is_registration_enabled(self):
+        return self.__registration_enabled
+
+    def is_registration_disabled(self):
+        return not self.is_registration_enabled()
 
     def add(self, id):
         self.__collectors[id] = time.time() + self.__expire_time
         LOG.info("Added collector {}. Collectors: {}".format(id, self.__collectors.keys()))
 
     def is_allowed(self, id):
+        if self.is_registration_disabled():
+            return True
+
         return id in self.__collectors.keys()
 
     def __check_all(self):

--- a/is_iot_sink/main.py
+++ b/is_iot_sink/main.py
@@ -31,6 +31,9 @@ def process_data():
         LOG.info("<{}> [{}]".format(message.topic, payload))
         
         if (message.topic == utils.get_setting("mqtt/topics/collector/registration")):
+            if ac.is_registration_disabled():
+                continue
+
             ac.add(payload["collectorId"])
             LOG.info("Collector [{}] accepted.".format(payload["collectorId"]))
 

--- a/setup.xml
+++ b/setup.xml
@@ -41,6 +41,7 @@
     <collectors>
         <!-- Time in seconds. 1h = 3600s -->
         <expireTime>3600</expireTime>
+        <registrationEnabled>false</registrationEnabled>
     </collectors>
     <irrigation>
         <initialMode>manual</initialMode>


### PR DESCRIPTION
This PR allows configuration for collector registration. The default value is set to 'False'.

Note: Only registered collectors are allowed to send data to sink node.